### PR TITLE
Centralized and lowered Cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25.2)
+cmake_minimum_required(VERSION 3.24.2)
 project(dimlp)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/dimlp/CMakeLists.txt
+++ b/dimlp/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.25.2)
 project(dimlp)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/dimlp/cpp/CMakeLists.txt
+++ b/dimlp/cpp/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.25.2)
 project(dimlp)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.25.2)
 project(example)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/example/cpp/CMakeLists.txt
+++ b/example/cpp/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.25.2)
 project(example)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/fidex/CMakeLists.txt
+++ b/fidex/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.25.2)
 project(fidex)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/fidex/cpp/CMakeLists.txt
+++ b/fidex/cpp/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.25.2)
 project(fidex)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/fidexGlo/CMakeLists.txt
+++ b/fidexGlo/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.25.2)
 project(fidexglo)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/fidexGlo/cpp/CMakeLists.txt
+++ b/fidexGlo/cpp/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.25.2)
 project(fidexglo)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/hyperLocus/CMakeLists.txt
+++ b/hyperLocus/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.25.2)
 project(hyperlocus)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/hyperLocus/cpp/CMakeLists.txt
+++ b/hyperLocus/cpp/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.25.2)
 project(hyperlocus)
 
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
* use only one minimum version macro in whole project
* use 3.24.2 as it is the highest version supported by CLion