### PR TITLE
Do not build when installing deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,21 +51,12 @@ jobs:
           cache: 'poetry'
 
       - name: Install Python dependencies
-        run: poetry install
-
-      - name: Create build dir
-        if: runner.os != 'Windows'
-        run: mkdir -p build
-
-      - name: Create build dir
-        if: runner.os == 'Windows'
-        run: |
-          rm -r build
-          mkdir build
+        run: poetry install --no-root
 
       - name: Compile
         if: runner.os != 'Windows'
         run: |
+          mkdir build
           cd build
           poetry run cmake ..
           poetry run cmake --build .
@@ -73,6 +64,7 @@ jobs:
       - name: Compile
         if: runner.os == 'Windows'
         run: |
+          mkdir build
           cd build
           $path = (poetry env info | Select-String -Pattern 'Path:\s+(.*)').Matches.Groups[1].Value
           poetry run cmake -G "MinGW Makefiles" -DCMAKE_PREFIX_PATH="$path" ..

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -44,7 +44,7 @@ jobs:
           cache: 'poetry'
 
       - name: Install Python dependencies
-        run: poetry install
+        run: poetry install --no-root
 
       - name: Compile
         run: |


### PR DESCRIPTION
By default, poetry install the project package every time with
'install'. This causes a cyclical issue where building requires
installing and then activating the virtual env before building,
which isn't possible to do before installing package.

Building at install time doesn't make sense in the CICD where the
building of binaries for publishing occurs.
