### PR TITLE
Add missing install instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,20 @@ poetry.exe --version
 
 ### Compile
 
+Activate the virtual environment:
+
+```shell
+poetry shell
+```
+
 Install python dependencies and compile:
 
 ```shell
 poetry install
 poetry build
 ```
+
+If CMake complains about not finding pybind11, ensure to activate the shell first.
 
 ### Install Pre-commit hooks
 


### PR DESCRIPTION
* The virtual environement must be activated with poetry shell
  to allow pybind11 to be found by cmake
