### PR TITLE
Update SonarCloud workflow

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -46,7 +46,7 @@ jobs:
         run: poetry install --no-root
 
       - name: Install sonar-scanner and build-wrapper
-        uses: SonarSource/sonarcloud-github-c-cpp@v1
+        uses: SonarSource/sonarcloud-github-c-cpp@v2
 
       - name: Run build-wrapper
         run: |


### PR DESCRIPTION
* Java 11 is deprecated, update the Sonar workflow to use Java 17 instead.