### PR TITLE
Add workaround for broken MinGW action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
         uses: egor-tensin/setup-mingw@v2
         with:
           platform: x64
+          version: 12.2.0
 
       - name: Set up GCC
         if: runner.os == 'macOS'


### PR DESCRIPTION
The MinGW action pluging egor-tensin/setup-mingw@v2, used for windows builds of our C++ components, is now failing. This is following the general availability of MinGW 13.1/13.2 (GCC 13).

A workaround is to pin the version to the last known working version (12.2.0).

See #74

