### PR TITLE
Fix workflow for windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,5 @@ jobs:
         run: poetry install --no-root
 
       - name: Compile
-        if: runner.os != 'Windows'
         run: |
           poetry build


### PR DESCRIPTION
Fix windows build in CI workflow.

This was disabled following an error in a refactoring of the pipeline (see c7b6a1b35a33902447117248b89e25974f76bc7b).
Python and dependencies as well as a C++ compiler were correctly installed, but the C++ code was
not compiled anymore for the windows target.

