### PR TITLE
Remove incompatible Python version in package workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ["3.11"] #  ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11"] #  ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest] # windows-latest
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest] # windows-latest,
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
* Python 3.12 is not compatible with tensorflow as of yet
