### PR TITLE
Remove python 3.8 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ["3.11"] #  ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.11"] #  ["3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cmake.exe --version
 
 ### Install Python
 
-Install [Python](https://www.python.org/), version 3.8.1 or newer (3.11 is recommended):
+Install [Python](https://www.python.org/), version 3.9 or newer (3.11 is recommended):
 
 * **Linux, macOS, Windows/WSL**: Use your package manager to install `python3` and `python3-dev`
 * **Windows**: `winget install Python.Python.3.11`


### PR DESCRIPTION
Keras 3 is not available for Python 3.8 which will be deprecated
in October 2024. Remove it.
