### PR TITLE
Adjust publish workflow to use cibuildwheel

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   PYTHON_VERSION: '3.11'
+  MACOSX_DEPLOYMENT_VERSION: '14.0' # TODO: lower this to latest supported 12.7 (breaks openmp at the moment)
 
 permissions:
   contents: write
@@ -20,7 +21,6 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
@@ -32,42 +32,37 @@ jobs:
         run: |
           git submodule update --init
 
-      - name: Set up GCC (Linux)
-        if: runner.os == 'Linux'
-        uses: egor-tensin/setup-gcc@v1
-        with:
-          version: latest
-          platform: x64
-
-      - name: Set up GCC (macOS)
+      - name: Set up Homebrew (macOS)
         if: runner.os == 'macOS'
-        uses: Dup4/actions-setup-gcc@v1
-        with:
-          version: latest
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
 
-      - name: Install cmake
-        uses: lukka/get-cmake@latest
+      - name: Install LLVM and OpenMP (Homebrew) # macOS's llvm does not support -fopenmp
+        if: runner.os == 'macOS'
+        run: |
+          brew install llvm libomp
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
 
-      - name: Install Python dependencies
+      - name: Install cibuildwheel
         run: |
-          python -m pip install -U pip
-          python -m pip install .
+          python -m pip install cibuildwheel==2.19.1
 
-      - name: Compile and Build archives
-        run: |
-          python -m build -w
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
+          CIBW_ARCH: auto64
+          CIBW_SKIP: "pp* *-win32 *-manylinux_i686 *musllinux* *-manylinux_ppc64le *-manylinux_s390x *-manylinux_aarch64"
+          CIBW_BUILD_FRONTEND: build
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=${{ env.MACOSX_DEPLOYMENT_VERSION }} PATH="/opt/homebrew/opt/llvm/bin:$PATH" CC="/opt/homebrew/opt/llvm/bin/clang" CXX="/opt/homebrew/opt/llvm/bin/clang++" LDFLAGS="-L/opt/homebrew/opt/libomp/lib -mmacosx-version-min=${{ env.MACOSX_DEPLOYMENT_VERSION }}" CPPFLAGS="-I/opt/homebrew/opt/libomp/include"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: artifact-dist-${{ matrix.os }}-${{ matrix.python-version }}
-          path: dist/*
+          name: artifact-dist-${{ matrix.os }}-${{ strategy.job-index }}
+          path: dist/*.whl
 
   source:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "torchvision>=0.18",
     "matplotlib>=3.7.4",
     "build>=1.0.3",
+    "cibuildwheel>=2.19.1",
     "breathe>=4.35.0",
     "exhale>=0.3.7",
     "sphinx>=7.3.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ classifiers=[
     'Programming Language :: C++',
     'Programming Language :: Python :: 3',
 ]
-requires-python = ">= 3.8.1"
+requires-python = ">= 3.9.0"
 
 [build-system]
 requires = ["scikit-build-core", "pybind11"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ torch>=2.3
 torchvision>=0.18
 matplotlib>=3.7.4
 build>=1.0.3
+cibuildwheel>=2.19.1
 breathe>=4.35.0
 exhale>=0.3.7
 sphinx>=7.3.7


### PR DESCRIPTION
Linux builds need to be build with a specific glibc and system libraries
versions to ensure the wheel is compatible on multiple distributions.

Rely on cibuildwheel which provides dockerised build containers.
