### PR TITLE
Add numpy version constraint for windows compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,7 @@ autoexe.sh
 tests/dataset/data/out/
 compile_commands.json
 /data/
+/dimlpfidex/
 
 # Sphinx
 docs/api

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 dependencies = [
     "pybind11>=2.10.4",
     "pybind11-global>=2.10.4",
-    "numpy>=1.22",
+    "numpy<2.0",
     "scikit-learn>=1.2.2",
     "keras>=3.3",
     "torch>=2.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pybind11>=2.10.4
 pybind11-global>=2.10.4
-numpy>=1.22
+numpy<2.0
 scikit-learn>=1.2.2
 keras>=3.3
 torch>=2.3


### PR DESCRIPTION
- **Add generatedlibrary folder to .gitignore**
- **Adjust numpy version constraint for windows compatibility**

Numpy 2.0 requires pybind 2.12, but despite matching this requirement
the windows build seems to not work as the keras 3.3.3 library has
seemingly been compile with numpy 1.x support only.

Downgrading the version constraint to numpy < 2.0 fixes the issue for
now. To be noted, that issue does not exist with Linux (and maybe
macOS?) and this fixes should be revisited once official support for
Keras 3 is added. 