### PR TITLE
Fix GUI path settings feature for web versions

### DIFF
--- a/dimlpfidex_gui/lib/views/home_view.dart
+++ b/dimlpfidex_gui/lib/views/home_view.dart
@@ -98,9 +98,10 @@ class MainMenuView extends StatelessWidget {
                   ),
                 ),
               ),
-              ElevatedButton(
-                  onPressed: () => _openSettingsDialog(context),
-                  child: const Icon(Icons.settings))
+              if (!kIsWeb)
+                ElevatedButton(
+                    onPressed: () => _openSettingsDialog(context),
+                    child: const Icon(Icons.settings))
             ],
           ),
         ));
@@ -174,7 +175,8 @@ void _openSettingsDialog(BuildContext context) async {
             actions: [
               SimpleButton(
                   onPressed: () {
-                    bool isValidDir = Directory.fromUri(Uri(path:path)).existsSync();
+                    bool isValidDir =
+                        Directory.fromUri(Uri(path: path)).existsSync();
 
                     if (!isValidDir || path.isEmpty) {
                       showSnackBar(context,


### PR DESCRIPTION
Minor fix to avoid displaying the path selection on the web version. This is done because, by default, browsers cannot have access to the user's file system.