### PR TITLE
Disable cache in documentation pipeline

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -41,7 +41,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
 
       - name: Install Sphinx and breathe (workaround)
         run: |
@@ -56,7 +55,7 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          cmake .. -DBUILD_DOCUMENTATION=ON
+          cmake -DBUILD_DOCUMENTATION=ON ..
           cmake --build .
 
       - name: Upload artifact


### PR DESCRIPTION
The behaviour obtained in local build and in the CICD seems different, with the Python documentation not fully
extracted despite a similar build process. Let's try to disable the pip cache to ensure no cache issue is responsible
for the divergent result.
