### PR TITLE
Add ninja as requirement for unix build

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $ git submodule update
 Install with your package manager:
 
 * a C++ compiler (gcc/g++)
+* the ninja build system (ninja or ninja-build)
 * cmake
 
 #### Windows


### PR DESCRIPTION
ninja is already a dependency on some Linux systems, but noton all of
them (f.e. Ubuntu). The package name is either ninja-build or ninja.

It is a installed automatically with MSVC on Windows.
