### PR TITLE
Relax scikit-learn version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "pybind11>=2.12.0",
     "pybind11-global>=2.10.4",
     "numpy<2.0",
-    "scikit-learn>=1.2.2",
+    "scikit-learn>=1.1.3",
     "keras>=3.3",
     "torch>=2.3",
     "torchvision>=0.18",


### PR DESCRIPTION
Omnixai unfortunately requires scikit-learn<1.2 due to a dependency requirement
